### PR TITLE
[#8] introduce editorconfig - to consolidate cross-editor code format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root=true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.java]
+indent_style = space
+indent_size = 4
+
+[*.xml]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
As developer I want to use my preferred editor for coding. But the special file formatting should be project dependent.

To fix [#8] I would introduce to use [editorconfig](https://editorconfig.org/) to consolidate the minimal formatting rules for cross-editor and cross-platform development.

* link: https://editorconfig.org/
* eclipse: https://marketplace.eclipse.org/content/editorconfig-eclipse
* intellij: https://plugins.jetbrains.com/plugin/7294-editorconfig

**Required**: 

* Installed plugins
* Reopening of source files. Editorconfig formatting happen on open file events. 

